### PR TITLE
[Feature] Adds Mix Node Count

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -53,4 +53,10 @@ th {
     background-color: var(--status-indicator-color-negative);
     animation-name: status-indicator-pulse-negative;
   }
+
+  #mixnodes-count > h2 {
+    color: #51cbce;
+    font-weight: bold;
+    margin-bottom: 10px;
+  }
   

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,6 +25,7 @@ function getTopology() {
     type: 'GET',
     url: topologyUrl,
     success: function (data) {
+      createMixnodeCount(data.mixNodes.length);
       createDisplayTable(data);
       updateNodesStatus();
     }
@@ -136,6 +137,10 @@ function setGatewayStatusDot(nodePubKey) {
   statusIndicator.setAttribute("active", "")
 
   dotWrapper.setAttribute("title", statusText)
+}
+
+function createMixnodeCount(mixNodeCount) {
+  var $h2 = $('h2').text(DOMPurify.sanitize(mixNodeCount)).appendTo("mixnodes-count");
 }
 
 function createMixnodeRows(mixNodes) {

--- a/index.html
+++ b/index.html
@@ -142,6 +142,17 @@ The above copyright notice and this permission notice shall be included in all c
           <div class="col-md-12">
             <div class="card">
               <div class="card-header">
+                <h4 class="card-title">Mix Node Count</h4>
+              </div>
+              <div class="card-body" id="mixnodes-count">
+                <h2></h2>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-md-12">
+            <div class="card">
+              <div class="card-header">
                 <h4 class="card-title"> Mix Nodes</h4>
               </div>
               <div class="card-body">


### PR DESCRIPTION
Hey folks,

Making a quick PR for a feature suggestion to add in a card at the top of the dashboard containing the current mixnode count. I think it might make it easier to get a high-level network glance compared to adding up the number of rows in the table.

Tried to follow the same general style guide as the rest of the repo; please feel free to code review as necessary.

**Changelog:**
- `assets/css/custom.css` - Styling changes for h2 tag
- `assets/js/main.js` - Addition of `createMixnodeCount` to calculate current mixnode count
- `index.html` - Addition of a new card for Mix Node Count

**Screenshot:**
![Screenshot](https://i.imgur.com/8lRdIv6.png)